### PR TITLE
Fixed formatting in TOC

### DIFF
--- a/content/toc.yml
+++ b/content/toc.yml
@@ -47,12 +47,12 @@
     - topicUid: DeviceStatus
     - topicUid: NextHealthMessageExpected
   - topicUid: AdapterDiagnostics
-      items:
-      - topicUid: System
-      - topicUid: StreamCount
-      - topicUid: IORate
-      - topicUid: ErrorRate
-      - topicUid: EgressDiagnostics
+    items:
+    - topicUid: System
+    - topicUid: StreamCount
+    - topicUid: IORate
+    - topicUid: ErrorRate
+    - topicUid: EgressDiagnostics
 - topicUid: TroubleshootTheAdapter
   items:
   - topicUid: TroubleshootPIAdapterForDNP3


### PR DESCRIPTION
Formatting issue in line 50 was causing a PowerShell exited with code ‘1’ error.